### PR TITLE
feat: apiserver support 10 year loopback cert

### DIFF
--- a/build/kube-apiserver-dr/Dockerfile
+++ b/build/kube-apiserver-dr/Dockerfile
@@ -1,0 +1,8 @@
+# Replaces the upstream kube-apiserver binary in the official v1.23.4 image.
+# Build context must be the Kubernetes repository root (see build.sh).
+
+FROM k8s.gcr.io/kube-apiserver:v1.23.4
+
+ARG TARGETARCH
+
+COPY _output/dockerized/bin/linux/${TARGETARCH}/kube-apiserver /usr/local/bin/kube-apiserver

--- a/build/kube-apiserver-dr/README.md
+++ b/build/kube-apiserver-dr/README.md
@@ -1,0 +1,45 @@
+# 定制 kube-apiserver 镜像（DR / 内部发行）
+
+本目录包含 **Dockerfile** 与 **`build.sh`**（真正执行 `make release-images` 与 `docker buildx` 的脚本）。Dockerfile 在官方 `k8s.gcr.io/kube-apiserver:v1.23.4` 镜像上替换 `kube-apiserver` 二进制。
+
+**构建上下文必须是仓库根目录**（`_output/dockerized/bin/linux/${TARGETARCH}/kube-apiserver` 相对根路径）。
+
+## 开发分支与合入
+
+1. 从 `v1.23.4-dr` 检出新分支进行修改  
+2. 向 `v1.23.4-dr` 提 PR  
+
+## 构建与推送
+
+在**仓库根目录**执行脚本（推荐）：
+
+```bash
+./build/kube-apiserver-dr/build.sh
+```
+
+发版时在命令前带上环境变量即可，**不必改脚本或 Dockerfile**：
+
+```bash
+IMAGE_REPO=registry.smtx.io/backup-dr/kube-apiserver IMAGE_TAG=v1.23.4-dr.0 ./build/kube-apiserver-dr/build.sh
+```
+
+脚本默认使用 `IMAGE_REPO=registry.smtx.io/backup-dr/kube-apiserver`、`IMAGE_TAG=v1.23.4-temp`（仅当对应变量未设置时）。
+
+### 等价的手动命令
+
+若不想用脚本，效果与 `build.sh` 相同：
+
+```bash
+export IMAGE_REPO="${IMAGE_REPO:-registry.smtx.io/backup-dr/kube-apiserver}"
+export IMAGE_TAG="${IMAGE_TAG:-v1.23.4-temp}"
+
+make release-images
+
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  --provenance=false \
+  -f build/kube-apiserver-dr/Dockerfile \
+  -t "${IMAGE_REPO}:${IMAGE_TAG}" \
+  --push \
+  .
+```

--- a/build/kube-apiserver-dr/build.sh
+++ b/build/kube-apiserver-dr/build.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Build and push multi-arch kube-apiserver (amd64 + arm64).
+# Run from repo root. Override when publishing:
+#   IMAGE_REPO=registry.smtx.io/sfs/kube-apiserver IMAGE_TAG=v1.23.4-dr.0 ./build/kube-apiserver-dr/build.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+make release-images
+
+IMAGE="${IMAGE_REPO:-registry.smtx.io/backup-dr/kube-apiserver}:${IMAGE_TAG:-v1.23.4-temp}"
+
+docker buildx build \
+	--platform linux/amd64,linux/arm64 \
+	--provenance=false \
+	-f "${SCRIPT_DIR}/Dockerfile" \
+	-t "${IMAGE}" \
+	--push \
+	.
+
+echo "Built: ${IMAGE}"

--- a/staging/src/k8s.io/client-go/util/cert/cert.go
+++ b/staging/src/k8s.io/client-go/util/cert/cert.go
@@ -36,7 +36,10 @@ import (
 	netutils "k8s.io/utils/net"
 )
 
-const duration365d = time.Hour * 24 * 365
+const (
+	duration365d = time.Hour * 24 * 365
+	duration10y  = duration365d * 10 // self-signed leaf + ephemeral CA validity
+)
 
 // Config contains the basic fields required for creating a certificate
 type Config struct {
@@ -65,7 +68,7 @@ func NewSelfSignedCACert(cfg Config, key crypto.Signer) (*x509.Certificate, erro
 		},
 		DNSNames:              []string{cfg.CommonName},
 		NotBefore:             now.UTC(),
-		NotAfter:              now.Add(duration365d * 10).UTC(),
+		NotAfter:              now.Add(duration10y).UTC(),
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		BasicConstraintsValid: true,
 		IsCA:                  true,
@@ -95,7 +98,7 @@ func GenerateSelfSignedCertKey(host string, alternateIPs []net.IP, alternateDNS 
 // Certs/keys not existing in that directory are created.
 func GenerateSelfSignedCertKeyWithFixtures(host string, alternateIPs []net.IP, alternateDNS []string, fixtureDirectory string) ([]byte, []byte, error) {
 	validFrom := time.Now().Add(-time.Hour) // valid an hour earlier to avoid flakes due to clock skew
-	maxAge := time.Hour * 24 * 365          // one year self-signed certs
+	maxAge := duration10y                   // ten-year self-signed certs (leaf and ephemeral CA)
 
 	baseName := fmt.Sprintf("%s_%s_%s", host, strings.Join(ipsToStrings(alternateIPs), "-"), strings.Join(alternateDNS, "-"))
 	certFixturePath := filepath.Join(fixtureDirectory, baseName+".crt")


### PR DESCRIPTION
修复 http://jira.smartx.com/browse/BAC-570


https://github.com/kubernetes/kubernetes/issues/86552 中提到：
> What happened:
If you never restart your kube-apiserver after 1 year, kube-apiserver can't works normal anymore.
What you expected to happen:
apiserver renew its LoopbackClient server cert.
How to reproduce it (as minimally and precisely as possible):
For quick reproduce, you can change your os date to 1 years later. Notes that there will be two cert expire, one for kubelet, one for apiserver inner LoopbackClient server cert.
kubelet can renew its cert via bootstrap token or existed kubeconfig, but apiserver seems never renew the in memory LoopbackClient server cert.

https://github.com/kubernetes/kubernetes/issues/86552#issuecomment-568492075
而且对于 k8s 社区，是没有延长这个过期时间或提供轮转的计划的。

---

参考阿里云的做法：
https://help.aliyun.com/zh/ack/product-overview/validity-period-change-for-api-server-internal-certificates
>API Server是ACK集群管控面的核心组件，其中内置了用于其内部[LoopbackClient](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/server/options/serving_with_loopback.go#L52-L61)服务端工作的证书。该证书在社区版本中有效期为[1年](https://github.com/kubernetes/kubernetes/blob/69c3b23abdbda53d14e14afc2af2bdfef23ac7b0/staging/src/k8s.io/client-go/util/cert/cert.go#L40C7-L40C19)且无法自动轮转，只有当API Server Pod发生重启时，才会自动轮转更新。社区暂无延长该证书有效期的计划，更多信息请参见[#86552](https://github.com/kubernetes/kubernetes/issues/86552#issuecomment-568492075)。
考虑到不同用户的运维习惯，容器服务 Kubernetes 版于近期调整了该内置证书的默认过期时间，修改后有效期为10年。


我们也提供一个魔改的 apiserver，将 apiserver 内部签发的证书有效期从默认一年改到十年。

将 apiserver 打包镜像上传至内部 Harbor。


打包镜像的逻辑 参考了 sfs 的做法：
https://github.com/iomesh/kubernetes/pull/5/changes#diff-a5d6c6edbb1a71a89e770e21163a088009f387673001a52de312db5326fbd34bR1-R4